### PR TITLE
Add Dockerfile to bake plugins into nomad-autoscaler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# nomad-autoscaler-plugins Dockerfile
+
+#
+# Build plugins in alpine container as upstream nomad-autoscaler does
+#
+
+FROM golang:alpine AS builder
+
+ADD . /src
+RUN apk add bash make \
+    && cd /src \
+    && make
+
+
+#
+# Install the plugins into the nomad-autoscaler images
+#
+
+FROM hashicorp/nomad-autoscaler:0.3.3
+
+COPY --from=builder /src/bin/plugins/* /plugins/


### PR DESCRIPTION
When deploying plugins into Dockerized `nomad-autoscaler`, the plugins must be built with Alpine Linux.  Otherwise, if one uses plugins built on non-Alpine Linux, one will see errors like this due glibc issues ([related bug](https://github.com/influxdata/influxdb/issues/5554)):

```
/plugins # ldd cron 
	/lib64/ld-linux-x86-64.so.2 (0x7f1b4d664000)
	libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7f1b4d664000)
	libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f1b4d664000)
Error relocating cron: __vfprintf_chk: symbol not found
Error relocating cron: __fprintf_chk: symbol not found
```

This PR adds a Dockerfile which builds these plugins under the `golang-alpine` and bakes them into the `nomad-autoscaler` Docker image at `/plugins`

Finally, thank you so much for creating this and sharing your work ❤️.  The absence of cron-oriented start/stop scheduling has limited my adoption of Nomad ... until today!    I'm surprised Kubernetes doesn't have this either.